### PR TITLE
fix: Remove comment from the test npm-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "# NODE_ENV=test babel-node ./src/index-test.js",
+    "test": "NODE_ENV=test babel-node ./src/index-test.js",
     "watch": "watch 'npm run -s test | tap-nirvana' src",
     "update": "updtr"
   },


### PR DESCRIPTION
**Proposed changes**

Remove a comment that causes the `npm test` script to fail silently.

<br/>

**Problem**

The `# `&nbsp;shell script comment causes the `npm test` script to do nothing:

![image](https://user-images.githubusercontent.com/2585460/80678098-3f46a080-8a88-11ea-9286-78a8237334ef.png)

It looks like `# ` was added in #11. Was that an intentional change to [this line of code](https://github.com/paralleldrive/tdd-rejection/pull/11/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R7)?

<br/>

**Demo**

![npm test](https://user-images.githubusercontent.com/2585460/80678447-e88d9680-8a88-11ea-859d-abde1a51a38b.gif)
